### PR TITLE
Add the International System of Units, the Metric system

### DIFF
--- a/src/Physics.NET.DevApp/Physics.NET.DevApp.csproj
+++ b/src/Physics.NET.DevApp/Physics.NET.DevApp.csproj
@@ -18,6 +18,8 @@
   <ItemGroup>
     <Using Include="Mathematics.NET" />
     <Using Include="Mathematics.NET.Core" />
+    <Using Include="Physics.NET" />
+    <Using Include="Physics.NET.DimensionalAnalysis" />
   </ItemGroup>
 
 </Project>

--- a/src/Physics.NET/DimensionalAnalysis/ISystemOfMeasurement.cs
+++ b/src/Physics.NET/DimensionalAnalysis/ISystemOfMeasurement.cs
@@ -1,0 +1,37 @@
+﻿// <copyright file="ISystemOfMeasurement.cs" company="Physics.NET">
+// Physics.NET
+// https://github.com/HamletTanyavong/Physics.NET
+//
+// MIT License
+//
+// Copyright (c) 2024-present Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+namespace Physics.NET.DimensionalAnalysis;
+
+/// <summary>Defines support for systems of measurement.</summary>
+/// <typeparam name="T">The type that implements the interface.</typeparam>
+public interface ISystemOfMeasurement<T>
+    where T : ISystemOfMeasurement<T>
+{
+    /// <summary>Represents no units.</summary>
+    static abstract T Dimensionless { get; }
+}

--- a/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/Ampere.cs
+++ b/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/Ampere.cs
@@ -1,0 +1,81 @@
+﻿// <copyright file="Ampere.cs" company="Physics.NET">
+// Physics.NET
+// https://github.com/HamletTanyavong/Physics.NET
+//
+// MIT License
+//
+// Copyright (c) 2024-present Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+using System.Runtime.InteropServices;
+
+namespace Physics.NET.DimensionalAnalysis.InternationalSystemOfUnits.BaseUnits;
+
+/// <summary>Represents the SI base unit of electric current.</summary>
+[StructLayout(LayoutKind.Sequential)]
+public readonly record struct Ampere : ICurrent<Ampere>
+{
+    public Ampere()
+    {
+        Exponent = new();
+    }
+
+    public Ampere(sbyte value)
+    {
+        Exponent = new(value);
+    }
+
+    public Ampere(Rational<sbyte> exponent)
+    {
+        Exponent = exponent;
+    }
+
+    public Ampere(sbyte numerator, sbyte denominator)
+    {
+        Exponent = new(numerator, denominator);
+    }
+
+    public readonly Rational<sbyte> Exponent { get; }
+
+    public static Ampere operator +(Ampere left, Ampere right) => new(left.Exponent + right.Exponent);
+
+    public static Ampere operator -(Ampere left, Ampere right) => new(left.Exponent - right.Exponent);
+
+    public readonly string ToLaTeX()
+    {
+        if (Rational<sbyte>.IsNaN(Exponent) || Rational<sbyte>.IsInfinity(Exponent))
+            return "Invalid base unit.";
+        if (Exponent.Num == 0)
+            return string.Empty;
+        if (Exponent.Den == 1)
+        {
+            if (Exponent.Num == 1)
+                return "\\text{A}";
+            else
+                return $"\\text{{A}}^{{{Exponent.Num}}}";
+        }
+        if (Exponent.Num < 0)
+            return $"\\text{{A}}^{{-\\frac{{{-Exponent.Num}}}{{{Exponent.Den}}}}}";
+        return $"\\text{{A}}^\\frac{{{Exponent.Num}}}{{{Exponent.Den}}}";
+    }
+
+    public static implicit operator Ampere(sbyte value) => new(value);
+}

--- a/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/Ampere.cs
+++ b/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/Ampere.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 namespace Physics.NET.DimensionalAnalysis.InternationalSystemOfUnits.BaseUnits;
 
 /// <summary>Represents the SI base unit of electric current.</summary>
-[StructLayout(LayoutKind.Sequential)]
+[Serializable, StructLayout(LayoutKind.Sequential)]
 public readonly record struct Ampere : ICurrent<Ampere>
 {
     public Ampere()

--- a/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/Candela.cs
+++ b/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/Candela.cs
@@ -1,0 +1,81 @@
+﻿// <copyright file="Candela.cs" company="Physics.NET">
+// Physics.NET
+// https://github.com/HamletTanyavong/Physics.NET
+//
+// MIT License
+//
+// Copyright (c) 2024-present Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+using System.Runtime.InteropServices;
+
+namespace Physics.NET.DimensionalAnalysis.InternationalSystemOfUnits.BaseUnits;
+
+/// <summary>Represents the SI base unit of luminous intensity.</summary>
+[StructLayout(LayoutKind.Sequential)]
+public readonly record struct Candela : IIntensity<Candela>
+{
+    public Candela()
+    {
+        Exponent = new();
+    }
+
+    public Candela(sbyte value)
+    {
+        Exponent = new(value);
+    }
+
+    public Candela(Rational<sbyte> exponent)
+    {
+        Exponent = exponent;
+    }
+
+    public Candela(sbyte numerator, sbyte denominator)
+    {
+        Exponent = new(numerator, denominator);
+    }
+
+    public readonly Rational<sbyte> Exponent { get; }
+
+    public static Candela operator +(Candela left, Candela right) => new(left.Exponent + right.Exponent);
+
+    public static Candela operator -(Candela left, Candela right) => new(left.Exponent - right.Exponent);
+
+    public readonly string ToLaTeX()
+    {
+        if (Rational<sbyte>.IsNaN(Exponent) || Rational<sbyte>.IsInfinity(Exponent))
+            return "Invalid base unit.";
+        if (Exponent.Num == 0)
+            return string.Empty;
+        if (Exponent.Den == 1)
+        {
+            if (Exponent.Num == 1)
+                return "\\text{cd}";
+            else
+                return $"\\text{{cd}}^{{{Exponent.Num}}}";
+        }
+        if (Exponent.Num < 0)
+            return $"\\text{{cd}}^{{-\\frac{{{-Exponent.Num}}}{{{Exponent.Den}}}}}";
+        return $"\\text{{cd}}^\\frac{{{Exponent.Num}}}{{{Exponent.Den}}}";
+    }
+
+    public static implicit operator Candela(sbyte value) => new(value);
+}

--- a/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/Candela.cs
+++ b/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/Candela.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 namespace Physics.NET.DimensionalAnalysis.InternationalSystemOfUnits.BaseUnits;
 
 /// <summary>Represents the SI base unit of luminous intensity.</summary>
-[StructLayout(LayoutKind.Sequential)]
+[Serializable, StructLayout(LayoutKind.Sequential)]
 public readonly record struct Candela : IIntensity<Candela>
 {
     public Candela()

--- a/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/IAmount.cs
+++ b/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/IAmount.cs
@@ -1,0 +1,33 @@
+﻿// <copyright file="IAmount.cs" company="Physics.NET">
+// Physics.NET
+// https://github.com/HamletTanyavong/Physics.NET
+//
+// MIT License
+//
+// Copyright (c) 2024-present Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+namespace Physics.NET.DimensionalAnalysis.InternationalSystemOfUnits.BaseUnits;
+
+/// <summary>Defines support for the SI base unit of an amount of substance.</summary>
+/// <typeparam name="T">The type that implements the interface.</typeparam>
+internal interface IAmount<T> : IBaseQuantity<T>
+    where T : IAmount<T>;

--- a/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/IAngle.cs
+++ b/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/IAngle.cs
@@ -1,0 +1,33 @@
+﻿// <copyright file="IAngle.cs" company="Physics.NET">
+// Physics.NET
+// https://github.com/HamletTanyavong/Physics.NET
+//
+// MIT License
+//
+// Copyright (c) 2024-present Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+namespace Physics.NET.DimensionalAnalysis.InternationalSystemOfUnits.BaseUnits;
+
+/// <summary>Defines support for the unit of a plane or phase angle.</summary>
+/// <typeparam name="T">The type that implements the interface.</typeparam>
+internal interface IAngle<T> : IBaseQuantity<T>
+    where T : IAngle<T>;

--- a/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/IBaseQuantity.cs
+++ b/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/IBaseQuantity.cs
@@ -1,0 +1,49 @@
+﻿// <copyright file="IBaseQuantity.cs" company="Physics.NET">
+// Physics.NET
+// https://github.com/HamletTanyavong/Physics.NET
+//
+// MIT License
+//
+// Copyright (c) 2024-present Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+using Mathematics.NET.Core.Operations;
+
+namespace Physics.NET.DimensionalAnalysis.InternationalSystemOfUnits.BaseUnits;
+
+/// <summary>Defines support for SI base quantities.</summary>
+/// <typeparam name="T">A type that implements the interface.</typeparam>
+internal interface IBaseQuantity<T>
+    : IAdditionOperation<T, T>,
+      ISubtractionOperation<T, T>
+    where T : IBaseQuantity<T>
+{
+    /// <summary>Represents the exponent of the base quantity.</summary>
+    Rational<sbyte> Exponent { get; }
+
+    /// <summary>Return a LaTeX representation of this base quantity.</summary>
+    /// <returns>A string.</returns>
+    string ToLaTeX();
+
+    /// <summary>Convert a <paramref name="value"/> into one of type <typeparamref name="T"/>.</summary>
+    /// <param name="value">An <see cref="sbyte"/> value.</param>
+    static abstract implicit operator T(sbyte value);
+}

--- a/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/IBaseUnits.cs
+++ b/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/IBaseUnits.cs
@@ -1,0 +1,69 @@
+﻿// <copyright file="IBaseUnits.cs" company="Physics.NET">
+// Physics.NET
+// https://github.com/HamletTanyavong/Physics.NET
+//
+// MIT License
+//
+// Copyright (c) 2024-present Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+namespace Physics.NET.DimensionalAnalysis.InternationalSystemOfUnits.BaseUnits;
+
+/// <summary>Represents the SI base units.</summary>
+/// <typeparam name="TBaseUnits">The type that implements the interface.</typeparam>
+/// <typeparam name="TTime">The type that represents the unit of time.</typeparam>
+/// <typeparam name="TLength">The type that represents the unit of length.</typeparam>
+/// <typeparam name="TMass">The type that represents the unit of mass.</typeparam>
+/// <typeparam name="TCurrent">The type that represents the unit of electric current.</typeparam>
+/// <typeparam name="TTemperature">The type that represents the unit of thermodynamic temperature.</typeparam>
+/// <typeparam name="TAmount">The type that represents the unit of an amount of substance.</typeparam>
+/// <typeparam name="TIntensity">The type that represents the unit of luminous intensity.</typeparam>
+internal interface IBaseUnits<TBaseUnits, TTime, TLength, TMass, TCurrent, TTemperature, TAmount, TIntensity>
+    where TBaseUnits : IBaseUnits<TBaseUnits, TTime, TLength, TMass, TCurrent, TTemperature, TAmount, TIntensity>
+    where TTime : ITime<TTime>
+    where TLength : ILength<TLength>
+    where TMass : IMass<TMass>
+    where TCurrent : ICurrent<TCurrent>
+    where TTemperature : ITemperature<TTemperature>
+    where TAmount : IAmount<TAmount>
+    where TIntensity : IIntensity<TIntensity>
+{
+    /// <summary>Represents the SI base quantity of time.</summary>
+    TTime Time { get; init; }
+
+    /// <summary>Represents the SI base quantity of length.</summary>
+    TLength Length { get; init; }
+
+    /// <summary>Represents the SI base quantity of mass.</summary>
+    TMass Mass { get; init; }
+
+    /// <summary>Represents the SI base quantity of electric current.</summary>
+    TCurrent Current { get; init; }
+
+    /// <summary>Represents the SI base quantity of thermodynamic temperature.</summary>
+    TTemperature Temperature { get; init; }
+
+    /// <summary>Represents the SI base quantity of an amount of substance.</summary>
+    TAmount Amount { get; init; }
+
+    /// <summary>Represents the SI base quantity of luminous intensity.</summary>
+    TIntensity Intensity { get; init; }
+}

--- a/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/IBaseUnits.cs
+++ b/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/IBaseUnits.cs
@@ -36,8 +36,9 @@ namespace Physics.NET.DimensionalAnalysis.InternationalSystemOfUnits.BaseUnits;
 /// <typeparam name="TTemperature">The type that represents the unit of thermodynamic temperature.</typeparam>
 /// <typeparam name="TAmount">The type that represents the unit of an amount of substance.</typeparam>
 /// <typeparam name="TIntensity">The type that represents the unit of luminous intensity.</typeparam>
-internal interface IBaseUnits<TBaseUnits, TTime, TLength, TMass, TCurrent, TTemperature, TAmount, TIntensity>
-    where TBaseUnits : IBaseUnits<TBaseUnits, TTime, TLength, TMass, TCurrent, TTemperature, TAmount, TIntensity>
+/// <typeparam name="TAngle">The type that represents the unit of a plane or phase angle.</typeparam>
+internal interface IBaseUnits<TBaseUnits, TTime, TLength, TMass, TCurrent, TTemperature, TAmount, TIntensity, TAngle>
+    where TBaseUnits : IBaseUnits<TBaseUnits, TTime, TLength, TMass, TCurrent, TTemperature, TAmount, TIntensity, TAngle>
     where TTime : ITime<TTime>
     where TLength : ILength<TLength>
     where TMass : IMass<TMass>
@@ -45,6 +46,7 @@ internal interface IBaseUnits<TBaseUnits, TTime, TLength, TMass, TCurrent, TTemp
     where TTemperature : ITemperature<TTemperature>
     where TAmount : IAmount<TAmount>
     where TIntensity : IIntensity<TIntensity>
+    where TAngle : IAngle<TAngle>
 {
     /// <summary>Represents the SI base quantity of time.</summary>
     TTime Time { get; init; }
@@ -66,4 +68,13 @@ internal interface IBaseUnits<TBaseUnits, TTime, TLength, TMass, TCurrent, TTemp
 
     /// <summary>Represents the SI base quantity of luminous intensity.</summary>
     TIntensity Intensity { get; init; }
+
+    // It is convenient to add the quantity, angle, since it makes structs that implement this
+    // interface have sizes of multiples of eight bytes, allowing for better performance optimizations.
+
+    /// <summary>Represents the quantity of a plane or phase angle.</summary>
+    /// <remarks>
+    /// In Physics.NET, this has been added to the SI base units for convenience. However, there are justifications for adding it formally. See <see href="https://iopscience.iop.org/article/10.1088/1681-7575/ac7bc2/pdf">On the Dimension of Angles and Their Units</see> by Peter J. Mohr, Eric L. Shirley, William D. Phillips, and Michael Trott. 
+    /// </remarks>
+    TAngle Angle { get; init; }
 }

--- a/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/ICurrent.cs
+++ b/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/ICurrent.cs
@@ -1,0 +1,33 @@
+﻿// <copyright file="ICurrent.cs" company="Physics.NET">
+// Physics.NET
+// https://github.com/HamletTanyavong/Physics.NET
+//
+// MIT License
+//
+// Copyright (c) 2024-present Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+namespace Physics.NET.DimensionalAnalysis.InternationalSystemOfUnits.BaseUnits;
+
+/// <summary>Defines support for the SI base unit of electric current.</summary>
+/// <typeparam name="T">The type that implements the interface.</typeparam>
+internal interface ICurrent<T> : IBaseQuantity<T>
+    where T : ICurrent<T>;

--- a/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/IIntensity.cs
+++ b/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/IIntensity.cs
@@ -1,0 +1,33 @@
+﻿// <copyright file="IIntensity.cs" company="Physics.NET">
+// Physics.NET
+// https://github.com/HamletTanyavong/Physics.NET
+//
+// MIT License
+//
+// Copyright (c) 2024-present Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+namespace Physics.NET.DimensionalAnalysis.InternationalSystemOfUnits.BaseUnits;
+
+/// <summary>Defines support for the SI base unit of luminous intensity.</summary>
+/// <typeparam name="T">The type that implements the interface.</typeparam>
+internal interface IIntensity<T> : IBaseQuantity<T>
+    where T : IIntensity<T>;

--- a/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/ILength.cs
+++ b/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/ILength.cs
@@ -1,0 +1,33 @@
+﻿// <copyright file="ILength.cs" company="Physics.NET">
+// Physics.NET
+// https://github.com/HamletTanyavong/Physics.NET
+//
+// MIT License
+//
+// Copyright (c) 2024-present Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+namespace Physics.NET.DimensionalAnalysis.InternationalSystemOfUnits.BaseUnits;
+
+/// <summary>Defines support for the SI base unit of length.</summary>
+/// <typeparam name="T">The type that implements the interface.</typeparam>
+internal interface ILength<T> : IBaseQuantity<T>
+    where T : ILength<T>;

--- a/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/IMass.cs
+++ b/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/IMass.cs
@@ -1,0 +1,33 @@
+﻿// <copyright file="IMass.cs" company="Physics.NET">
+// Physics.NET
+// https://github.com/HamletTanyavong/Physics.NET
+//
+// MIT License
+//
+// Copyright (c) 2024-present Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+namespace Physics.NET.DimensionalAnalysis.InternationalSystemOfUnits.BaseUnits;
+
+/// <summary>Defines support for the SI base unit of mass.</summary>
+/// <typeparam name="T">The type that implements the interface.</typeparam>
+internal interface IMass<T> : IBaseQuantity<T>
+    where T : IMass<T>;

--- a/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/ITemperature.cs
+++ b/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/ITemperature.cs
@@ -1,0 +1,33 @@
+﻿// <copyright file="ITemperature.cs" company="Physics.NET">
+// Physics.NET
+// https://github.com/HamletTanyavong/Physics.NET
+//
+// MIT License
+//
+// Copyright (c) 2024-present Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+namespace Physics.NET.DimensionalAnalysis.InternationalSystemOfUnits.BaseUnits;
+
+/// <summary>Defines support for the SI base unit of thermodynamic temperature.</summary>
+/// <typeparam name="TTemperature">The type that implements the interface.</typeparam>
+internal interface ITemperature<TTemperature> : IBaseQuantity<TTemperature>
+    where TTemperature : ITemperature<TTemperature>;

--- a/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/ITime.cs
+++ b/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/ITime.cs
@@ -1,0 +1,33 @@
+﻿// <copyright file="ITime.cs" company="Physics.NET">
+// Physics.NET
+// https://github.com/HamletTanyavong/Physics.NET
+//
+// MIT License
+//
+// Copyright (c) 2024-present Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+namespace Physics.NET.DimensionalAnalysis.InternationalSystemOfUnits.BaseUnits;
+
+/// <summary>Defines support for the SI base unit of time.</summary>
+/// <typeparam name="T">The type that implements the interface.</typeparam>
+internal interface ITime<T> : IBaseQuantity<T>
+    where T : ITime<T>;

--- a/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/Kelvin.cs
+++ b/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/Kelvin.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 namespace Physics.NET.DimensionalAnalysis.InternationalSystemOfUnits.BaseUnits;
 
 /// <summary>Represents the SI base unit of thermodynamic temperature.</summary>
-[StructLayout(LayoutKind.Sequential)]
+[Serializable, StructLayout(LayoutKind.Sequential)]
 public readonly record struct Kelvin : ITemperature<Kelvin>
 {
     public Kelvin()

--- a/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/Kelvin.cs
+++ b/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/Kelvin.cs
@@ -1,0 +1,81 @@
+﻿// <copyright file="Kelvin.cs" company="Physics.NET">
+// Physics.NET
+// https://github.com/HamletTanyavong/Physics.NET
+//
+// MIT License
+//
+// Copyright (c) 2024-present Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+using System.Runtime.InteropServices;
+
+namespace Physics.NET.DimensionalAnalysis.InternationalSystemOfUnits.BaseUnits;
+
+/// <summary>Represents the SI base unit of thermodynamic temperature.</summary>
+[StructLayout(LayoutKind.Sequential)]
+public readonly record struct Kelvin : ITemperature<Kelvin>
+{
+    public Kelvin()
+    {
+        Exponent = new();
+    }
+
+    public Kelvin(sbyte value)
+    {
+        Exponent = new(value);
+    }
+
+    public Kelvin(Rational<sbyte> exponent)
+    {
+        Exponent = exponent;
+    }
+
+    public Kelvin(sbyte numerator, sbyte denominator)
+    {
+        Exponent = new(numerator, denominator);
+    }
+
+    public readonly Rational<sbyte> Exponent { get; }
+
+    public static Kelvin operator +(Kelvin left, Kelvin right) => new(left.Exponent + right.Exponent);
+
+    public static Kelvin operator -(Kelvin left, Kelvin right) => new(left.Exponent - right.Exponent);
+
+    public readonly string ToLaTeX()
+    {
+        if (Rational<sbyte>.IsNaN(Exponent) || Rational<sbyte>.IsInfinity(Exponent))
+            return "Invalid base unit.";
+        if (Exponent.Num == 0)
+            return string.Empty;
+        if (Exponent.Den == 1)
+        {
+            if (Exponent.Num == 1)
+                return "\\text{K}";
+            else
+                return $"\\text{{K}}^{{{Exponent.Num}}}";
+        }
+        if (Exponent.Num < 0)
+            return $"\\text{{K}}^{{-\\frac{{{-Exponent.Num}}}{{{Exponent.Den}}}}}";
+        return $"\\text{{K}}^\\frac{{{Exponent.Num}}}{{{Exponent.Den}}}";
+    }
+
+    public static implicit operator Kelvin(sbyte value) => new(value);
+}

--- a/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/Kilogram.cs
+++ b/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/Kilogram.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 namespace Physics.NET.DimensionalAnalysis.InternationalSystemOfUnits.BaseUnits;
 
 /// <summary>Represents the SI base unit of mass.</summary>
-[StructLayout(LayoutKind.Sequential)]
+[Serializable, StructLayout(LayoutKind.Sequential)]
 public readonly record struct Kilogram : IMass<Kilogram>
 {
     public Kilogram()

--- a/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/Kilogram.cs
+++ b/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/Kilogram.cs
@@ -1,0 +1,81 @@
+﻿// <copyright file="Kilogram.cs" company="Physics.NET">
+// Physics.NET
+// https://github.com/HamletTanyavong/Physics.NET
+//
+// MIT License
+//
+// Copyright (c) 2024-present Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+using System.Runtime.InteropServices;
+
+namespace Physics.NET.DimensionalAnalysis.InternationalSystemOfUnits.BaseUnits;
+
+/// <summary>Represents the SI base unit of mass.</summary>
+[StructLayout(LayoutKind.Sequential)]
+public readonly record struct Kilogram : IMass<Kilogram>
+{
+    public Kilogram()
+    {
+        Exponent = new();
+    }
+
+    public Kilogram(sbyte value)
+    {
+        Exponent = new(value);
+    }
+
+    public Kilogram(Rational<sbyte> exponent)
+    {
+        Exponent = exponent;
+    }
+
+    public Kilogram(sbyte numerator, sbyte denominator)
+    {
+        Exponent = new(numerator, denominator);
+    }
+
+    public readonly Rational<sbyte> Exponent { get; }
+
+    public static Kilogram operator +(Kilogram left, Kilogram right) => new(left.Exponent + right.Exponent);
+
+    public static Kilogram operator -(Kilogram left, Kilogram right) => new(left.Exponent - right.Exponent);
+
+    public readonly string ToLaTeX()
+    {
+        if (Rational<sbyte>.IsNaN(Exponent) || Rational<sbyte>.IsInfinity(Exponent))
+            return "Invalid base unit.";
+        if (Exponent.Num == 0)
+            return string.Empty;
+        if (Exponent.Den == 1)
+        {
+            if (Exponent.Num == 1)
+                return "\\text{kg}";
+            else
+                return $"\\text{{kg}}^{{{Exponent.Num}}}";
+        }
+        if (Exponent.Num < 0)
+            return $"\\text{{kg}}^{{-\\frac{{{-Exponent.Num}}}{{{Exponent.Den}}}}}";
+        return $"\\text{{kg}}^\\frac{{{Exponent.Num}}}{{{Exponent.Den}}}";
+    }
+
+    public static implicit operator Kilogram(sbyte value) => new(value);
+}

--- a/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/Meter.cs
+++ b/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/Meter.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 namespace Physics.NET.DimensionalAnalysis.InternationalSystemOfUnits.BaseUnits;
 
 /// <summary>Represents the SI base unit of length.</summary>
-[StructLayout(LayoutKind.Sequential)]
+[Serializable, StructLayout(LayoutKind.Sequential)]
 public readonly record struct Meter : ILength<Meter>
 {
     public Meter()

--- a/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/Meter.cs
+++ b/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/Meter.cs
@@ -1,0 +1,81 @@
+﻿// <copyright file="Meter.cs" company="Physics.NET">
+// Physics.NET
+// https://github.com/HamletTanyavong/Physics.NET
+//
+// MIT License
+//
+// Copyright (c) 2024-present Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+using System.Runtime.InteropServices;
+
+namespace Physics.NET.DimensionalAnalysis.InternationalSystemOfUnits.BaseUnits;
+
+/// <summary>Represents the SI base unit of length.</summary>
+[StructLayout(LayoutKind.Sequential)]
+public readonly record struct Meter : ILength<Meter>
+{
+    public Meter()
+    {
+        Exponent = new();
+    }
+
+    public Meter(sbyte value)
+    {
+        Exponent = new(value);
+    }
+
+    public Meter(Rational<sbyte> exponent)
+    {
+        Exponent = exponent;
+    }
+
+    public Meter(sbyte numerator, sbyte denominator)
+    {
+        Exponent = new(numerator, denominator);
+    }
+
+    public readonly Rational<sbyte> Exponent { get; }
+
+    public static Meter operator +(Meter left, Meter right) => new(left.Exponent + right.Exponent);
+
+    public static Meter operator -(Meter left, Meter right) => new(left.Exponent - right.Exponent);
+
+    public readonly string ToLaTeX()
+    {
+        if (Rational<sbyte>.IsNaN(Exponent) || Rational<sbyte>.IsInfinity(Exponent))
+            return "Invalid base unit.";
+        if (Exponent.Num == 0)
+            return string.Empty;
+        if (Exponent.Den == 1)
+        {
+            if (Exponent.Num == 1)
+                return "\\text{m}";
+            else
+                return $"\\text{{m}}^{{{Exponent.Num}}}";
+        }
+        if (Exponent.Num < 0)
+            return $"\\text{{m}}^{{-\\frac{{{-Exponent.Num}}}{{{Exponent.Den}}}}}";
+        return $"\\text{{m}}^\\frac{{{Exponent.Num}}}{{{Exponent.Den}}}";
+    }
+
+    public static implicit operator Meter(sbyte value) => new(value);
+}

--- a/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/Mole.cs
+++ b/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/Mole.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 namespace Physics.NET.DimensionalAnalysis.InternationalSystemOfUnits.BaseUnits;
 
 /// <summary>Represents the SI base unit of an amount of substance.</summary>
-[StructLayout(LayoutKind.Sequential)]
+[Serializable, StructLayout(LayoutKind.Sequential)]
 public readonly record struct Mole : IAmount<Mole>
 {
     public Mole()

--- a/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/Mole.cs
+++ b/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/Mole.cs
@@ -1,0 +1,81 @@
+﻿// <copyright file="Mole.cs" company="Physics.NET">
+// Physics.NET
+// https://github.com/HamletTanyavong/Physics.NET
+//
+// MIT License
+//
+// Copyright (c) 2024-present Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+using System.Runtime.InteropServices;
+
+namespace Physics.NET.DimensionalAnalysis.InternationalSystemOfUnits.BaseUnits;
+
+/// <summary>Represents the SI base unit of an amount of substance.</summary>
+[StructLayout(LayoutKind.Sequential)]
+public readonly record struct Mole : IAmount<Mole>
+{
+    public Mole()
+    {
+        Exponent = new();
+    }
+
+    public Mole(sbyte value)
+    {
+        Exponent = new(value);
+    }
+
+    public Mole(Rational<sbyte> exponent)
+    {
+        Exponent = exponent;
+    }
+
+    public Mole(sbyte numerator, sbyte denominator)
+    {
+        Exponent = new(numerator, denominator);
+    }
+
+    public readonly Rational<sbyte> Exponent { get; }
+
+    public static Mole operator +(Mole left, Mole right) => new(left.Exponent + right.Exponent);
+
+    public static Mole operator -(Mole left, Mole right) => new(left.Exponent - right.Exponent);
+
+    public readonly string ToLaTeX()
+    {
+        if (Rational<sbyte>.IsNaN(Exponent) || Rational<sbyte>.IsInfinity(Exponent))
+            return "Invalid base unit.";
+        if (Exponent.Num == 0)
+            return string.Empty;
+        if (Exponent.Den == 1)
+        {
+            if (Exponent.Num == 1)
+                return "\\text{mol}";
+            else
+                return $"\\text{{mol}}^{{{Exponent.Num}}}";
+        }
+        if (Exponent.Num < 0)
+            return $"\\text{{mol}}^{{-\\frac{{{-Exponent.Num}}}{{{Exponent.Den}}}}}";
+        return $"\\text{{mol}}^\\frac{{{Exponent.Num}}}{{{Exponent.Den}}}";
+    }
+
+    public static implicit operator Mole(sbyte value) => new(value);
+}

--- a/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/Radian.cs
+++ b/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/Radian.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 namespace Physics.NET.DimensionalAnalysis.InternationalSystemOfUnits.BaseUnits;
 
 /// <summary>Represents the unit of a plane or phase angle.</summary>
-[StructLayout(LayoutKind.Sequential)]
+[Serializable, StructLayout(LayoutKind.Sequential)]
 public readonly record struct Radian : IAngle<Radian>
 {
     public Radian()

--- a/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/Radian.cs
+++ b/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/Radian.cs
@@ -1,0 +1,81 @@
+﻿// <copyright file="Radian.cs" company="Physics.NET">
+// Physics.NET
+// https://github.com/HamletTanyavong/Physics.NET
+//
+// MIT License
+//
+// Copyright (c) 2024-present Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+using System.Runtime.InteropServices;
+
+namespace Physics.NET.DimensionalAnalysis.InternationalSystemOfUnits.BaseUnits;
+
+/// <summary>Represents the unit of a plane or phase angle.</summary>
+[StructLayout(LayoutKind.Sequential)]
+public readonly record struct Radian : IAngle<Radian>
+{
+    public Radian()
+    {
+        Exponent = new();
+    }
+
+    public Radian(sbyte value)
+    {
+        Exponent = new(value);
+    }
+
+    public Radian(Rational<sbyte> exponent)
+    {
+        Exponent = exponent;
+    }
+
+    public Radian(sbyte numerator, sbyte denominator)
+    {
+        Exponent = new(numerator, denominator);
+    }
+
+    public readonly Rational<sbyte> Exponent { get; }
+
+    public static Radian operator +(Radian left, Radian right) => new(left.Exponent + right.Exponent);
+
+    public static Radian operator -(Radian left, Radian right) => new(left.Exponent - right.Exponent);
+
+    public readonly string ToLaTeX()
+    {
+        if (Rational<sbyte>.IsNaN(Exponent) || Rational<sbyte>.IsInfinity(Exponent))
+            return "Invalid unit.";
+        if (Exponent.Num == 0)
+            return string.Empty;
+        if (Exponent.Den == 1)
+        {
+            if (Exponent.Num == 1)
+                return "\\text{rad}";
+            else
+                return $"\\text{{rad}}^{{{Exponent.Num}}}";
+        }
+        if (Exponent.Num < 0)
+            return $"\\text{{rad}}^{{-\\frac{{{-Exponent.Num}}}{{{Exponent.Den}}}}}";
+        return $"\\text{{rad}}^\\frac{{{Exponent.Num}}}{{{Exponent.Den}}}";
+    }
+
+    public static implicit operator Radian(sbyte value) => new(value);
+}

--- a/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/Second.cs
+++ b/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/Second.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 namespace Physics.NET.DimensionalAnalysis.InternationalSystemOfUnits.BaseUnits;
 
 /// <summary>Represents the SI base unit of time.</summary>
-[StructLayout(LayoutKind.Sequential)]
+[Serializable, StructLayout(LayoutKind.Sequential)]
 public readonly record struct Second : ITime<Second>
 {
     public Second()

--- a/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/Second.cs
+++ b/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/BaseUnits/Second.cs
@@ -1,0 +1,81 @@
+﻿// <copyright file="Second.cs" company="Physics.NET">
+// Physics.NET
+// https://github.com/HamletTanyavong/Physics.NET
+//
+// MIT License
+//
+// Copyright (c) 2024-present Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+using System.Runtime.InteropServices;
+
+namespace Physics.NET.DimensionalAnalysis.InternationalSystemOfUnits.BaseUnits;
+
+/// <summary>Represents the SI base unit of time.</summary>
+[StructLayout(LayoutKind.Sequential)]
+public readonly record struct Second : ITime<Second>
+{
+    public Second()
+    {
+        Exponent = new();
+    }
+
+    public Second(sbyte value)
+    {
+        Exponent = new(value);
+    }
+
+    public Second(Rational<sbyte> exponent)
+    {
+        Exponent = exponent;
+    }
+
+    public Second(sbyte numerator, sbyte denominator)
+    {
+        Exponent = new(numerator, denominator);
+    }
+
+    public readonly Rational<sbyte> Exponent { get; }
+
+    public static Second operator +(Second left, Second right) => new(left.Exponent + right.Exponent);
+
+    public static Second operator -(Second left, Second right) => new(left.Exponent - right.Exponent);
+
+    public readonly string ToLaTeX()
+    {
+        if (Rational<sbyte>.IsNaN(Exponent) || Rational<sbyte>.IsInfinity(Exponent))
+            return "Invalid base unit.";
+        if (Exponent.Num == 0)
+            return string.Empty;
+        if (Exponent.Den == 1)
+        {
+            if (Exponent.Num == 1)
+                return "\\text{s}";
+            else
+                return $"\\text{{s}}^{{{Exponent.Num}}}";
+        }
+        if (Exponent.Num < 0)
+            return $"\\text{{s}}^{{-\\frac{{{-Exponent.Num}}}{{{Exponent.Den}}}}}";
+        return $"\\text{{s}}^\\frac{{{Exponent.Num}}}{{{Exponent.Den}}}";
+    }
+
+    public static implicit operator Second(sbyte value) => new(value);
+}

--- a/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/DerivedUnits/IDerivedQuantity.cs
+++ b/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/DerivedUnits/IDerivedQuantity.cs
@@ -1,0 +1,33 @@
+﻿// <copyright file="IDerivedQuantity.cs" company="Physics.NET">
+// Physics.NET
+// https://github.com/HamletTanyavong/Physics.NET
+//
+// MIT License
+//
+// Copyright (c) 2024-present Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+namespace Physics.NET.DimensionalAnalysis.InternationalSystemOfUnits.DerivedUnits;
+
+/// <summary>Defines support for SI derived quantities.</summary>
+/// <typeparam name="T">A type that implements the interface.</typeparam>
+internal interface IDerivedQuantity<T>
+    where T : IDerivedQuantity<T>;

--- a/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/DerivedUnits/IDerivedUnits.cs
+++ b/src/Physics.NET/DimensionalAnalysis/InternationalSystemOfUnits/DerivedUnits/IDerivedUnits.cs
@@ -1,0 +1,99 @@
+﻿// <copyright file="IDerivedUnits.cs" company="Physics.NET">
+// Physics.NET
+// https://github.com/HamletTanyavong/Physics.NET
+//
+// MIT License
+//
+// Copyright (c) 2024-present Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+using Physics.NET.DimensionalAnalysis.InternationalSystemOfUnits.BaseUnits;
+
+namespace Physics.NET.DimensionalAnalysis.InternationalSystemOfUnits.DerivedUnits;
+
+/// <summary>Defines support for the relevant, named SI coherent derived units.</summary>
+/// <remarks>
+/// The unit for plane and phase angles can be found in <see cref="IBaseUnits{TBaseUnits, TTime, TLength, TMass, TCurrent, TTemperature, TAmount, TIntensity, TAngle}"/>.
+/// </remarks>
+/// <typeparam name="T">The type that implements the interface.</typeparam>
+internal interface IDerivedUnits<T>
+    where T : IDerivedUnits<T>
+{
+    /// <summary>Represents the quantity of ionizing radiation dose.</summary>
+    static abstract T AbsorbedDose { get; }
+
+    /// <summary>Represents the quantity of catalytic activity.</summary>
+    static abstract T CatalyticActivity { get; }
+
+    /// <summary>Represents the quantity of electric charge.</summary>
+    static abstract T ElectricCharge { get; }
+
+    /// <summary>Represents the quantity of electrical capacitance.</summary>
+    static abstract T ElectricalCapacitance { get; }
+
+    /// <summary>Represents the quantity of electrical conductance.</summary>
+    static abstract T ElectricalConductance { get; }
+
+    /// <summary>Represents the quantity of electrical inductance.</summary>
+    static abstract T ElectricalInductance { get; }
+
+    /// <summary>Represents the quantity of electrical potential difference.</summary>
+    static abstract T ElectricalPotentialDifference { get; }
+
+    /// <summary>Represents the quantity of electrical resistance.</summary>
+    static abstract T ElectricalResistance { get; }
+
+    /// <summary>Represents the quantity of energy.</summary>
+    static abstract T Energy { get; }
+
+    /// <summary>Represents the quantity of equivalent dose.</summary>
+    static abstract T EquivalentDose { get; }
+
+    /// <summary>Represents the quantity of force.</summary>
+    static abstract T Force { get; }
+
+    /// <summary>Represents the quantity of frequency.</summary>
+    static abstract T Frequency { get; }
+
+    /// <summary>Represents the quantity of illuminance.</summary>
+    static abstract T Illuminance { get; }
+
+    /// <summary>Represents the quantity of luminous flux.</summary>
+    static abstract T LuminousFlux { get; }
+
+    /// <summary>Represents the quantity of magnetic flux.</summary>
+    static abstract T MagneticFlux { get; }
+
+    /// <summary>Represents the quantity of magnetic induction.</summary>
+    static abstract T MagneticInduction { get; }
+
+    /// <summary>Represents the quantity of power.</summary>
+    static abstract T Power { get; }
+
+    /// <summary>Represents the quantity of pressure.</summary>
+    static abstract T Pressure { get; }
+
+    /// <summary>Represents the quantity of radioactivity.</summary>
+    static abstract T Radioactivity { get; }
+
+    /// <summary>Represents the quantity of a solid angle.</summary>
+    static abstract T SolidAngle { get; }
+}

--- a/src/Physics.NET/DimensionalAnalysis/InvalidUnitsException.cs
+++ b/src/Physics.NET/DimensionalAnalysis/InvalidUnitsException.cs
@@ -1,0 +1,40 @@
+﻿// <copyright file="InvalidUnitsException.cs" company="Physics.NET">
+// Physics.NET
+// https://github.com/HamletTanyavong/Physics.NET
+//
+// MIT License
+//
+// Copyright (c) 2024-present Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+namespace Physics.NET.DimensionalAnalysis;
+
+/// <summary>Represents errors that occur when units of quantities do not match the required units of certain operations.</summary>
+internal class InvalidUnitsException : Exception
+{
+    public InvalidUnitsException() { }
+
+    public InvalidUnitsException(string message)
+        : base(message) { }
+
+    public InvalidUnitsException(string message, Exception innerException)
+        : base(message, innerException) { }
+}

--- a/src/Physics.NET/DimensionalAnalysis/Metric.cs
+++ b/src/Physics.NET/DimensionalAnalysis/Metric.cs
@@ -27,6 +27,7 @@
 
 using System.Runtime.InteropServices;
 using Physics.NET.DimensionalAnalysis.InternationalSystemOfUnits.BaseUnits;
+using Physics.NET.DimensionalAnalysis.InternationalSystemOfUnits.DerivedUnits;
 
 namespace Physics.NET.DimensionalAnalysis;
 
@@ -36,10 +37,71 @@ namespace Physics.NET.DimensionalAnalysis;
 [Serializable, StructLayout(LayoutKind.Sequential)]
 public readonly record struct Metric
     : ISystemOfMeasurement<Metric>,
-      IBaseUnits<Metric, Second, Meter, Kilogram, Ampere, Kelvin, Mole, Candela, Radian>
+      IBaseUnits<Metric, Second, Meter, Kilogram, Ampere, Kelvin, Mole, Candela, Radian>,
+      IDerivedUnits<Metric>
 {
     /// <inheritdoc cref="ISystemOfMeasurement{T}.Dimensionless"/>
     public static readonly Metric Dimensionless = new();
+
+    /// <summary>Represents the derived unit of ionizing radiation dose, measured in <i>grays</i>.</summary>
+    public static readonly Metric AbsorbedDose = new() { Time = -2, Length = 2 };
+
+    /// <summary>Represents the derived unit of catalytic activity, measured in <i>katals</i>.</summary>
+    public static readonly Metric CatalyticActivity = new() { Time = -1, Amount = 1 };
+
+    /// <summary>Represents the derived unit of electric charge, measured in <i>coulombs</i>.</summary>
+    public static readonly Metric ElectricCharge = new() { Time = 1, Current = 1 };
+
+    /// <summary>Represents the derived unit of electrical capacitance, measured in <i>farads</i>.</summary>
+    public static readonly Metric ElectricalCapacitance = new() { Time = 4, Length = -2, Mass = -1, Current = 2 };
+
+    /// <summary>Represents the derived unit of electrical conductance, measured in <i>siemens</i>.</summary>
+    public static readonly Metric ElectricalConductance = new() { Time = 3, Length = -2, Mass = -1, Current = 2 };
+
+    /// <summary>Represents the derived unit of electrical inductance, measured in <i>henries</i>.</summary>
+    public static readonly Metric ElectricalInductance = new() { Time = -2, Length = 2, Mass = 1, Current = -2 };
+
+    /// <summary>Represents the derived unit of electrical potential difference, measured in <i>volts</i>.</summary>
+    public static readonly Metric ElectricalPotentialDifference = new() { Time = -3, Length = 2, Mass = 1, Current = -1 };
+
+    /// <summary>Represents the derived unit of electrical resistance, measured in <i>ohms</i>.</summary>
+    public static readonly Metric ElectricalResistance = new() { Time = -3, Length = 2, Mass = 1, Current = -2 };
+
+    /// <summary>Represents the derived unit of energy, measured in <i>joules</i>.</summary>
+    public static readonly Metric Energy = new() { Time = -2, Length = 2, Mass = 1 };
+
+    /// <summary>Represents the derived unit of equivalent dose, measured in <i>sieverts</i>.</summary>
+    public static readonly Metric EquivalentDose = new() { Time = -2, Length = 2 };
+
+    /// <summary>Represents the derived unit of force, measured in <i>newtons</i>.</summary>
+    public static readonly Metric Force = new() { Time = -2, Length = 1, Mass = 1 };
+
+    /// <summary>Represents the derived unit of frequency, measured in <i>hertz</i>.</summary>
+    public static readonly Metric Frequency = new() { Time = -1 };
+
+    /// <summary>Represents the derived unit of illuminance, measured in <i>lux</i>.</summary>
+    public static readonly Metric Illuminance = new() { Length = -2, Intensity = 1, Angle = 2 };
+
+    /// <summary>Represents the derived unit of luminous flux, measured in <i>lumens</i>.</summary>
+    public static readonly Metric LuminousFlux = new() { Intensity = 1, Angle = 2 };
+
+    /// <summary>Represents the derived unit of magnetic flux, measured in <i>webers</i>.</summary>
+    public static readonly Metric MagneticFlux = new() { Time = -2, Length = 2, Mass = 1, Current = -1 };
+
+    /// <summary>Represents the derived unit of magnetic induction, measured in <i>teslas</i>.</summary>
+    public static readonly Metric MagneticInduction = new() { Time = -2, Mass = 1, Current = -1 };
+
+    /// <summary>Represents the derived unit of power, measured in <i>watts</i>.</summary>
+    public static readonly Metric Power = new() { Time = -3, Length = 2, Mass = 1 };
+
+    /// <summary>Represents the derived unit of pressure, measured in <i>pascals</i>.</summary>
+    public static readonly Metric Pressure = new() { Time = -2, Length = -1, Mass = 1 };
+
+    /// <summary>Represents the derived unit of radioactivity, measured in <i>becquerels</i>.</summary>
+    public static readonly Metric Radioactivity = new() { Time = -1 };
+
+    /// <summary>Represents the derived unit of a solid angle, measured in <i>steradians</i>.</summary>
+    public static readonly Metric SolidAngle = new() { Angle = 2 };
 
     public Metric() { }
 
@@ -48,6 +110,27 @@ public readonly record struct Metric
     //
 
     static Metric ISystemOfMeasurement<Metric>.Dimensionless => Dimensionless;
+
+    static Metric IDerivedUnits<Metric>.AbsorbedDose => AbsorbedDose;
+    static Metric IDerivedUnits<Metric>.CatalyticActivity => CatalyticActivity;
+    static Metric IDerivedUnits<Metric>.ElectricCharge => ElectricCharge;
+    static Metric IDerivedUnits<Metric>.ElectricalCapacitance => ElectricalCapacitance;
+    static Metric IDerivedUnits<Metric>.ElectricalConductance => ElectricalConductance;
+    static Metric IDerivedUnits<Metric>.ElectricalInductance => ElectricalInductance;
+    static Metric IDerivedUnits<Metric>.ElectricalPotentialDifference => ElectricalPotentialDifference;
+    static Metric IDerivedUnits<Metric>.ElectricalResistance => ElectricalResistance;
+    static Metric IDerivedUnits<Metric>.Energy => Energy;
+    static Metric IDerivedUnits<Metric>.EquivalentDose => EquivalentDose;
+    static Metric IDerivedUnits<Metric>.Force => Force;
+    static Metric IDerivedUnits<Metric>.Frequency => Frequency;
+    static Metric IDerivedUnits<Metric>.Illuminance => Illuminance;
+    static Metric IDerivedUnits<Metric>.LuminousFlux => LuminousFlux;
+    static Metric IDerivedUnits<Metric>.MagneticFlux => MagneticFlux;
+    static Metric IDerivedUnits<Metric>.MagneticInduction => MagneticInduction;
+    static Metric IDerivedUnits<Metric>.Power => Power;
+    static Metric IDerivedUnits<Metric>.Pressure => Pressure;
+    static Metric IDerivedUnits<Metric>.Radioactivity => Radioactivity;
+    static Metric IDerivedUnits<Metric>.SolidAngle => SolidAngle;
 
     //
     // Base Units

--- a/src/Physics.NET/DimensionalAnalysis/Metric.cs
+++ b/src/Physics.NET/DimensionalAnalysis/Metric.cs
@@ -33,7 +33,7 @@ namespace Physics.NET.DimensionalAnalysis;
 /// <summary>
 /// Represents the <i>International System of Units</i>, the <i>Metric system</i>, as coordinated by the <see href="https://www.bipm.org">International Bureau of Weights and Measurements</see>.
 /// </summary>
-[StructLayout(LayoutKind.Sequential)]
+[Serializable, StructLayout(LayoutKind.Sequential)]
 public readonly record struct Metric
     : ISystemOfMeasurement<Metric>,
       IBaseUnits<Metric, Second, Meter, Kilogram, Ampere, Kelvin, Mole, Candela, Radian>

--- a/src/Physics.NET/DimensionalAnalysis/Metric.cs
+++ b/src/Physics.NET/DimensionalAnalysis/Metric.cs
@@ -1,0 +1,63 @@
+﻿// <copyright file="Metric.cs" company="Physics.NET">
+// Physics.NET
+// https://github.com/HamletTanyavong/Physics.NET
+//
+// MIT License
+//
+// Copyright (c) 2024-present Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+using System.Runtime.InteropServices;
+using Physics.NET.DimensionalAnalysis.InternationalSystemOfUnits.BaseUnits;
+
+namespace Physics.NET.DimensionalAnalysis;
+
+/// <summary>
+/// Represents the <i>International System of Units</i>, the <i>Metric system</i>, as coordinated by the <see href="https://www.bipm.org">International Bureau of Weights and Measurements</see>.
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+public readonly record struct Metric
+    : ISystemOfMeasurement<Metric>,
+      IBaseUnits<Metric, Second, Meter, Kilogram, Ampere, Kelvin, Mole, Candela, Radian>
+{
+    public static readonly Metric Dimensionless = new();
+
+    public Metric() { }
+
+    //
+    // Interface Implementations
+    //
+
+    static Metric ISystemOfMeasurement<Metric>.Dimensionless => Dimensionless;
+
+    //
+    // Base Units
+    //
+
+    public readonly Second Time { get; init; } = new();
+    public readonly Meter Length { get; init; } = new();
+    public readonly Kilogram Mass { get; init; } = new();
+    public readonly Ampere Current { get; init; } = new();
+    public readonly Kelvin Temperature { get; init; } = new();
+    public readonly Mole Amount { get; init; } = new();
+    public readonly Candela Intensity { get; init; } = new();
+    public readonly Radian Angle { get; init; } = new();
+}

--- a/src/Physics.NET/DimensionalAnalysis/Metric.cs
+++ b/src/Physics.NET/DimensionalAnalysis/Metric.cs
@@ -38,6 +38,7 @@ public readonly record struct Metric
     : ISystemOfMeasurement<Metric>,
       IBaseUnits<Metric, Second, Meter, Kilogram, Ampere, Kelvin, Mole, Candela, Radian>
 {
+    /// <inheritdoc cref="ISystemOfMeasurement{T}.Dimensionless"/>
     public static readonly Metric Dimensionless = new();
 
     public Metric() { }

--- a/src/Physics.NET/Physics.NET.csproj
+++ b/src/Physics.NET/Physics.NET.csproj
@@ -36,6 +36,7 @@
   <ItemGroup>
     <Using Include="Mathematics.NET" />
     <Using Include="Mathematics.NET.Core" />
+    <Using Include="Physics.NET.DimensionalAnalysis" />
   </ItemGroup>
 
 </Project>

--- a/src/Physics.NET/Quantity.cs
+++ b/src/Physics.NET/Quantity.cs
@@ -25,8 +25,6 @@
 // SOFTWARE.
 // </copyright>
 
-#pragma warning disable IDE0032
-
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Runtime.Intrinsics;
@@ -36,6 +34,7 @@ namespace Physics.NET;
 /// <summary>Represents a physical quantity.</summary>
 /// <typeparam name="TNumber">The type that represents the value.</typeparam>
 /// <typeparam name="TSystemOfMeasurement">The system of measurement to use.</typeparam>
+[Serializable]
 public readonly record struct Quantity<TNumber, TSystemOfMeasurement>
     where TNumber : IComplex<TNumber>
     where TSystemOfMeasurement : ISystemOfMeasurement<TSystemOfMeasurement>

--- a/src/Physics.NET/Quantity.cs
+++ b/src/Physics.NET/Quantity.cs
@@ -1,0 +1,60 @@
+﻿// <copyright file="Quantity.cs" company="Physics.NET">
+// Physics.NET
+// https://github.com/HamletTanyavong/Physics.NET
+//
+// MIT License
+//
+// Copyright (c) 2024-present Hamlet Tanyavong
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+
+namespace Physics.NET;
+
+/// <summary>Represents a physical quantity.</summary>
+/// <typeparam name="TNumber">The type that represents the value.</typeparam>
+/// <typeparam name="TSystemOfMeasurement">The system of measurement to use.</typeparam>
+public readonly record struct Quantity<TNumber, TSystemOfMeasurement>
+    where TNumber : IComplex<TNumber>
+    where TSystemOfMeasurement : ISystemOfMeasurement<TSystemOfMeasurement>
+{
+    public Quantity()
+    {
+        Value = TNumber.Zero;
+        Units = TSystemOfMeasurement.Dimensionless;
+    }
+
+    public Quantity(TNumber value)
+    {
+        Value = value;
+        Units = TSystemOfMeasurement.Dimensionless;
+    }
+
+    public Quantity(TNumber value, TSystemOfMeasurement units)
+    {
+        Value = value;
+        Units = units;
+    }
+
+    /// <summary>The value of the quantity.</summary>
+    public readonly TNumber Value { get; }
+
+    /// <summary>The units of the quantity.</summary>
+    public readonly TSystemOfMeasurement Units { get; }
+}


### PR DESCRIPTION
Add base units from the International System of Units (SI) along with most of its coherent derived units. Exceptions are the unit _radian_ and the unit _degree Celsius._ The former has been added to the base units for convenience, while the latter has been omitted since the base unit _kelvin_ exists and has the same dimensions. (The unit _degree Celsius_ may be added in the future if deemed necessary.)