### PR TITLE
Update Quantity.cs

### DIFF
--- a/src/Physics.NET/Quantity.cs
+++ b/src/Physics.NET/Quantity.cs
@@ -72,23 +72,11 @@ public readonly record struct Quantity<TNumber, TSystemOfMeasurement>
     [Conditional("UNITS")]
     public void VerifyUnits(in TSystemOfMeasurement units)
     {
-        if (Vector128.IsHardwareAccelerated)
+        if (!Vector128.EqualsAll(
+            Unsafe.As<TSystemOfMeasurement, Vector128<ulong>>(ref Unsafe.AsRef(in _units)),
+            Unsafe.As<TSystemOfMeasurement, Vector128<ulong>>(ref Unsafe.AsRef(in units))))
         {
-            if (!Vector128.EqualsAll(
-                Unsafe.As<TSystemOfMeasurement, Vector128<ulong>>(ref Unsafe.AsRef(in _units)),
-                Unsafe.As<TSystemOfMeasurement, Vector128<ulong>>(ref Unsafe.AsRef(in units))))
-            {
-                throw new InvalidUnitsException($"The units of the quantity are invalid.");
-            }
-        }
-        else
-        {
-            if (!Vector64.EqualsAll(
-                Unsafe.As<TSystemOfMeasurement, Vector64<ulong>>(ref Unsafe.AsRef(in _units)),
-                Unsafe.As<TSystemOfMeasurement, Vector64<ulong>>(ref Unsafe.AsRef(in units))))
-            {
-                throw new InvalidUnitsException($"The units of the quantity are invalid.");
-            }
+            throw new InvalidUnitsException($"The units of the quantity are invalid.");
         }
     }
 }


### PR DESCRIPTION
Remove the option to use 64-bit vector operations if 128-bit vector operations are not hardware accelerated. The current implementation does not work as intended as it only checks the first four units.